### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -47,7 +47,7 @@ add_custom_command(OUTPUT ${SPHINX_INDEX_FILE}
 	DEPENDS 
 		# Other docs files you want to track should go here (or in some variable)
 		${CMAKE_CURRENT_SOURCE_DIR}/index.rst
-		${DOXYGEN_INDEX_FILE}
+		Doxygen
 	MAIN_DEPENDENCY ${SPHINX_SOURCE}/conf.py
 	COMMENT "Generating documentation with Sphinx")
 


### PR DESCRIPTION
Sphinx command should depend on Doxygen instead of DOXYGEN_INDEX_FILE directly.  This prevents doxygen from running twice in parallel make.
https://gist.github.com/socantre/7ee63133a0a3a08f3990